### PR TITLE
Ensures the fedora id is sent in the body on reindex.

### DIFF
--- a/fcrepo-indexing-http/pom.xml
+++ b/fcrepo-indexing-http/pom.xml
@@ -45,6 +45,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-mustache</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>${project.parent.groupId}</groupId>
       <artifactId>fcrepo-camel-common</artifactId>
       <version>${project.parent.version}</version>

--- a/fcrepo-indexing-http/src/main/java/org/fcrepo/camel/indexing/http/HttpRouter.java
+++ b/fcrepo-indexing-http/src/main/java/org/fcrepo/camel/indexing/http/HttpRouter.java
@@ -17,7 +17,11 @@
  */
 package org.fcrepo.camel.indexing.http;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.camel.Exchange;
+import org.apache.camel.Expression;
 import org.apache.camel.LoggingLevel;
+import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.support.builder.Namespaces;
 import org.fcrepo.camel.processor.EventProcessor;
@@ -35,7 +39,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 public class HttpRouter extends RouteBuilder {
 
-    private static final Logger logger = getLogger(HttpRouter.class);
+    private static final Logger LOGGER = getLogger(HttpRouter.class);
 
     @Autowired
     private FcrepoHttpIndexerConfig config;
@@ -76,7 +80,8 @@ public class HttpRouter extends RouteBuilder {
          * Forward message to Http
          */
         from("direct:send.to.http").routeId("FcrepoHttpSend")
-            .log(LoggingLevel.INFO, logger, "sending to http...")
+            .log(LoggingLevel.INFO, LOGGER, "sending ${headers[CamelFcrepoUri]} to http endpoint...")
+            .to("mustache:org/fcrepo/camel/indexing/http/reindex.mustache")
             .setHeader(HTTP_METHOD).constant("POST")
             .to(config.getHttpBaseUrl());
     }

--- a/fcrepo-indexing-http/src/main/resources/org/fcrepo/camel/indexing/http/reindex.mustache
+++ b/fcrepo-indexing-http/src/main/resources/org/fcrepo/camel/indexing/http/reindex.mustache
@@ -1,0 +1,5 @@
+{
+  "reindex" : {
+    "id" : "{{headers.CamelFcrepoUri}}"
+  }
+}


### PR DESCRIPTION
Try this.  Since reindexing uses a different path, it does not have an Activity Streams compliant json message like we have when receiving messages directly from fcrepo.  Therefore I'm using a mustache template to pull in the fedora id on it's way out to the external http service.